### PR TITLE
Update JGit

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -28,7 +28,7 @@ class MillGitCross(millVersion: String)
     ivy"com.lihaoyi::mill-scalalib:$millVersion",
     ivy"com.lihaoyi::mill-contrib-docker:$millVersion"
   )
-  override def ivyDeps = super.ivyDeps() ++ Agg(ivy"org.eclipse.jgit:org.eclipse.jgit:6.0.0.202111291000-r")
+  override def ivyDeps = super.ivyDeps() ++ Agg(ivy"org.eclipse.jgit:org.eclipse.jgit:6.3.0.202209071007-r")
 
   override def publishVersion = GitVersionModule.version(withSnapshotSuffix = true)()
   def pomSettings = PomSettings(


### PR DESCRIPTION
Hi @joan38, when I run Mill on Windows using this plugin, I'm getting the following error:
```
java.io.IOException: The process cannot access the file because another process has locked a portion of the file
    java.base/java.io.FileInputStream.read0(Native Method)
    java.base/java.io.FileInputStream.read(FileInputStream.java:228)
    org.eclipse.jgit.util.IO.readWholeStream(IO.java:169)
    org.eclipse.jgit.treewalk.WorkingTreeIterator.possiblyFilteredInputStream(WorkingTreeIterator.java:418)
    org.eclipse.jgit.treewalk.WorkingTreeIterator.possiblyFilteredInputStream(WorkingTreeIterator.java:404)
    org.eclipse.jgit.treewalk.WorkingTreeIterator.getEntryContentLength(WorkingTreeIterator.java:617)
    org.eclipse.jgit.api.AddCommand.call(AddCommand.java:200)
    com.goyeau.mill.git.GitVersionModule$.uncommittedHash(GitVersionModule.scala:59)
    com.goyeau.mill.git.GitVersionModule$.uncommitted$1(GitVersionModule.scala:21)
    com.goyeau.mill.git.GitVersionModule$.$anonfun$version$4(GitVersionModule.scala:24)
    scala.util.Success.fold(Try.scala:281)
    com.goyeau.mill.git.GitVersionModule$.$anonfun$version$2(GitVersionModule.scala:25)
```
The [changelog for JGit 6.2.0](https://projects.eclipse.org/projects/technology.jgit/releases/6.2.0/) mentions sth. possibly related:

> [579445](https://eclip.se/579445) Remove stray files (probes or lock files) created by background threads

My hope is that the update fixes this, not sure though.