### PR TITLE
Use T.workspace in Git.open()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checks
         run: |
           git config --global user.name "CI"
-          ./mill all __.checkStyle __.docJar __.test
+          ./mill all __.checkStyle __.docJar __.publishLocal __.test
       - name: Publish
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release'
         run: |

--- a/build.sc
+++ b/build.sc
@@ -7,12 +7,12 @@ import com.goyeau.mill.scalafix.StyleModule
 import de.tobiasroeser.mill.integrationtest._
 import mill._
 import mill.scalalib._
-import mill.scalalib.api.Util.scalaNativeBinaryVersion
+import mill.scalalib.api.ZincWorkerUtil.scalaNativeBinaryVersion
 import mill.scalalib.publish.{Developer, License, PomSettings, VersionControl}
 import org.typelevel.scalacoptions.ScalacOptions._
 import org.typelevel.scalacoptions.{ScalaVersion, ScalacOptions}
 
-val millVersions                           = Seq("0.10.12", "0.11.1")
+val millVersions                           = Seq("0.10.12", "0.11.1", "0.12.4")
 def millBinaryVersion(millVersion: String) = scalaNativeBinaryVersion(millVersion)
 
 object `mill-git` extends Cross[MillGitCross](millVersions: _*)

--- a/itest/src/custom/build.sc
+++ b/itest/src/custom/build.sc
@@ -12,59 +12,59 @@ object project extends JavaModule {
 def setupUncommittedChanges = T.input {
   remove.all(pwd / ".git")
 
-  proc("git", "init").call()
+  proc("git", "init").call(cwd = T.workspace)
 }
 def uncommittedChanges() = T.command {
   setupUncommittedChanges()
 
   assert("""[\da-f]{7}""".r.findFirstIn(project.jobVersion()).isDefined)
 
-  remove.all(pwd / ".git")
+  remove.all(T.workspace / ".git")
 }
 
 // Commit without tag
 def setupCommitWithoutTag = T.input {
-  remove.all(pwd / ".git")
+  remove.all(T.workspace / ".git")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
 }
 def commitWithoutTag() = T.command {
   setupCommitWithoutTag()
 
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(project.jobVersion() == hash)
 
-  remove.all(pwd / ".git")
+  remove.all(T.workspace / ".git")
 }
 
 // Uncommitted changes after commit without tag
 def setupUncommittedChangesAfterCommitWithoutTag = T.input {
-  remove.all(pwd / ".git")
-  remove(pwd / "some-file")
+  remove.all(T.workspace / ".git")
+  remove(T.workspace / "some-file")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  write(pwd / "some-file", "Some change!")
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  write(T.workspace / "some-file", "Some change!")
 }
 def uncommittedChangesAfterCommitWithoutTag() = T.command {
   setupUncommittedChangesAfterCommitWithoutTag()
 
   assert("""[\da-f]{7}""".r.findFirstIn(project.jobVersion()).isDefined)
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(!project.jobVersion().contains(hash))
 }
 
 // Head tagged
 def setupHeadTagged = T.input {
-  remove.all(pwd / ".git")
+  remove.all(T.workspace / ".git")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call()
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call(cwd = T.workspace)
 }
 def headTagged() = T.command {
   setupHeadTagged()
@@ -74,61 +74,61 @@ def headTagged() = T.command {
 
 // Uncommitted changes after tag
 def setupUncommittedChangesAfterTag = T.input {
-  remove.all(pwd / ".git")
-  remove(pwd / "some-file")
+  remove.all(T.workspace / ".git")
+  remove(T.workspace / "some-file")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call()
-  write(pwd / "some-file", "Some change!")
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call(cwd = T.workspace)
+  write(T.workspace / "some-file", "Some change!")
 }
 def uncommittedChangesAfterTag() = T.command {
   setupUncommittedChangesAfterTag()
 
   assert("""1\.0\.0-1-[\da-f]{7}""".r.findFirstIn(project.jobVersion()).isDefined)
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(!project.jobVersion().contains(hash))
 }
 
 // Commit after tag
 def setupCommitAfterTag = T.input {
-  remove.all(pwd / ".git")
-  remove(pwd / "some-file")
+  remove.all(T.workspace / ".git")
+  remove(T.workspace / "some-file")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call()
-  write(pwd / "some-file", "Some change!")
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit 2").call()
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call(cwd = T.workspace)
+  write(T.workspace / "some-file", "Some change!")
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit 2").call(cwd = T.workspace)
 }
 def commitAfterTag() = T.command {
   setupCommitAfterTag()
 
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(project.jobVersion() == s"1.0.0-1-$hash")
 }
 
 // Uncommitted changes after tag and after commit
 def setupUncommittedChangesAfterTagAndCommit = T.input {
-  remove.all(pwd / ".git")
-  remove(pwd / "some-file")
+  remove.all(T.workspace / ".git")
+  remove(T.workspace / "some-file")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call()
-  write(pwd / "some-file", "Some change!")
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit 2").call()
-  write.over(pwd / "some-file", "Some change 2!")
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call(cwd = T.workspace)
+  write(T.workspace / "some-file", "Some change!")
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit 2").call(cwd = T.workspace)
+  write.over(T.workspace / "some-file", "Some change 2!")
 }
 def uncommittedChangesAfterTagAndCommit() = T.command {
   setupUncommittedChangesAfterTagAndCommit()
 
   assert("""1\.0\.0-2-[\da-f]{7}""".r.findFirstIn(project.jobVersion()).isDefined)
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(!project.jobVersion().contains(hash))
 }

--- a/itest/src/custom/build.sc
+++ b/itest/src/custom/build.sc
@@ -10,7 +10,7 @@ object project extends JavaModule {
 
 // Uncommitted changes
 def setupUncommittedChanges = T.input {
-  remove.all(pwd / ".git")
+  remove.all(T.workspace / ".git")
 
   proc("git", "init").call(cwd = T.workspace)
 }

--- a/itest/src/docker/build.sc
+++ b/itest/src/docker/build.sc
@@ -14,9 +14,9 @@ object project extends JavaModule with GitTaggedDockerModule {
 
 // Uncommitted changes
 def setupUncommittedChanges = T.input {
-  remove.all(pwd / ".git")
+  remove.all(T.workspace / ".git")
 
-  proc("git", "init").call()
+  proc("git", "init").call(cwd = T.workspace)
 }
 def uncommittedChanges() = T.command {
   setupUncommittedChanges()
@@ -29,16 +29,16 @@ def uncommittedChanges() = T.command {
 
 // Commit without tag
 def setupCommitWithoutTag = T.input {
-  remove.all(pwd / ".git")
+  remove.all(T.workspace / ".git")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
 }
 def commitWithoutTag() = T.command {
   setupCommitWithoutTag()
 
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   val tags = project.docker.tags()
   assert(tags.size == 2)
   assert(tags(0) == s"project:$hash")
@@ -47,13 +47,13 @@ def commitWithoutTag() = T.command {
 
 // Uncommitted changes after commit without tag
 def setupUncommittedChangesAfterCommitWithoutTag = T.input {
-  remove.all(pwd / ".git")
-  remove(pwd / "some-file")
+  remove.all(T.workspace / ".git")
+  remove(T.workspace / "some-file")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  write(pwd / "some-file", "Some change!")
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  write(T.workspace / "some-file", "Some change!")
 }
 def uncommittedChangesAfterCommitWithoutTag() = T.command {
   setupUncommittedChangesAfterCommitWithoutTag()
@@ -61,19 +61,19 @@ def uncommittedChangesAfterCommitWithoutTag() = T.command {
   val tags = project.docker.tags()
   assert(tags.size == 2)
   assert("""project:[\da-f]{7}""".r.findFirstIn(tags(0)).isDefined)
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(!tags(0).contains(hash))
   assert(tags(1) == "project:latest")
 }
 
 // Head tagged
 def setupHeadTagged = T.input {
-  remove.all(pwd / ".git")
+  remove.all(T.workspace / ".git")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call()
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call(cwd = T.workspace)
 }
 def headTagged() = T.command {
   setupHeadTagged()
@@ -86,14 +86,14 @@ def headTagged() = T.command {
 
 // Uncommitted changes after tag
 def setupUncommittedChangesAfterTag = T.input {
-  remove.all(pwd / ".git")
-  remove(pwd / "some-file")
+  remove.all(T.workspace / ".git")
+  remove(T.workspace / "some-file")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call()
-  write(pwd / "some-file", "Some change!")
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call(cwd = T.workspace)
+  write(T.workspace / "some-file", "Some change!")
 }
 def uncommittedChangesAfterTag() = T.command {
   setupUncommittedChangesAfterTag()
@@ -101,47 +101,47 @@ def uncommittedChangesAfterTag() = T.command {
   val tags = project.docker.tags()
   assert(tags.size == 2)
   assert("""project:1\.0\.0-1-[\da-f]{7}""".r.findFirstIn(tags(0)).isDefined)
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(!tags(0).contains(hash))
   assert(tags(1) == "project:latest")
 }
 
 // Commit after tag
 def setupCommitAfterTag = T.input {
-  remove.all(pwd / ".git")
-  remove(pwd / "some-file")
+  remove.all(T.workspace / ".git")
+  remove(T.workspace / "some-file")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call()
-  write(pwd / "some-file", "Some change!")
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit 2").call()
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call(cwd = T.workspace)
+  write(T.workspace / "some-file", "Some change!")
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit 2").call(cwd = T.workspace)
 }
 def commitAfterTag() = T.command {
   setupCommitAfterTag()
 
   val tags = project.docker.tags()
   assert(tags.size == 2)
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(tags(0) == s"project:1.0.0-1-$hash")
   assert(tags(1) == "project:latest")
 }
 
 // Uncommitted changes after tag and after commit
 def setupUncommittedChangesAfterTagAndCommit = T.input {
-  remove.all(pwd / ".git")
-  remove(pwd / "some-file")
+  remove.all(T.workspace / ".git")
+  remove(T.workspace / "some-file")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call()
-  write(pwd / "some-file", "Some change!")
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit 2").call()
-  write.over(pwd / "some-file", "Some change 2!")
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call(cwd = T.workspace)
+  write(T.workspace / "some-file", "Some change!")
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit 2").call(cwd = T.workspace)
+  write.over(T.workspace / "some-file", "Some change 2!")
 }
 def uncommittedChangesAfterTagAndCommit() = T.command {
   setupUncommittedChangesAfterTagAndCommit()
@@ -149,7 +149,7 @@ def uncommittedChangesAfterTagAndCommit() = T.command {
   val tags = project.docker.tags()
   assert(tags.size == 2)
   assert("""project:1\.0\.0-2-[\da-f]{7}""".r.findFirstIn(tags(0)).isDefined)
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(!tags(0).contains(hash))
   assert(tags(1) == "project:latest")
 }

--- a/itest/src/publish/build.sc
+++ b/itest/src/publish/build.sc
@@ -18,9 +18,9 @@ object project extends JavaModule with GitVersionedPublishModule {
 
 // Uncommitted changes
 def setupUncommittedChanges = T.input {
-  remove.all(pwd / ".git")
+  remove.all(T.workspace / ".git")
 
-  proc("git", "init").call()
+  proc("git", "init").call(cwd = T.workspace)
 }
 def uncommittedChanges() = T.command {
   setupUncommittedChanges()
@@ -30,45 +30,45 @@ def uncommittedChanges() = T.command {
 
 // Commit without tag
 def setupCommitWithoutTag = T.input {
-  remove.all(pwd / ".git")
+  remove.all(T.workspace / ".git")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
 }
 def commitWithoutTag() = T.command {
   setupCommitWithoutTag()
 
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(project.publishVersion() == hash)
 }
 
 // Uncommitted changes after commit without tag
 def setupUncommittedChangesAfterCommitWithoutTag = T.input {
-  remove.all(pwd / ".git")
-  remove(pwd / "some-file")
+  remove.all(T.workspace / ".git")
+  remove(T.workspace / "some-file")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  write(pwd / "some-file", "Some change!")
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  write(T.workspace / "some-file", "Some change!")
 }
 def uncommittedChangesAfterCommitWithoutTag() = T.command {
   setupUncommittedChangesAfterCommitWithoutTag()
 
   assert("""[\da-f]{7}""".r.findFirstIn(project.publishVersion()).isDefined)
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(!project.publishVersion().contains(hash))
 }
 
 // Head tagged
 def setupHeadTagged = T.input {
-  remove.all(pwd / ".git")
+  remove.all(T.workspace / ".git")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call()
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call(cwd = T.workspace)
 }
 def headTagged() = T.command {
   setupHeadTagged()
@@ -78,61 +78,61 @@ def headTagged() = T.command {
 
 // Uncommitted changes after tag
 def setupUncommittedChangesAfterTag = T.input {
-  remove.all(pwd / ".git")
-  remove(pwd / "some-file")
+  remove.all(T.workspace / ".git")
+  remove(T.workspace / "some-file")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call()
-  write(pwd / "some-file", "Some change!")
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call(cwd = T.workspace)
+  write(T.workspace / "some-file", "Some change!")
 }
 def uncommittedChangesAfterTag() = T.command {
   setupUncommittedChangesAfterTag()
 
   assert("""1\.0\.0-1-[\da-f]{7}""".r.findFirstIn(project.publishVersion()).isDefined)
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(!project.publishVersion().contains(hash))
 }
 
 // Commit after tag
 def setupCommitAfterTag = T.input {
-  remove.all(pwd / ".git")
-  remove(pwd / "some-file")
+  remove.all(T.workspace / ".git")
+  remove(T.workspace / "some-file")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call()
-  write(pwd / "some-file", "Some change!")
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit 2").call()
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call(cwd = T.workspace)
+  write(T.workspace / "some-file", "Some change!")
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit 2").call(cwd = T.workspace)
 }
 def commitAfterTag() = T.command {
   setupCommitAfterTag()
 
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(project.publishVersion() == s"1.0.0-1-$hash")
 }
 
 // Uncommitted changes after tag and after commit
 def setupUncommittedChangesAfterTagAndCommit = T.input {
-  remove.all(pwd / ".git")
-  remove(pwd / "some-file")
+  remove.all(T.workspace / ".git")
+  remove(T.workspace / "some-file")
 
-  proc("git", "init").call()
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit").call()
-  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call()
-  write(pwd / "some-file", "Some change!")
-  proc("git", "add", "--all").call()
-  proc("git", "commit", "-m", "Some commit 2").call()
-  write.over(pwd / "some-file", "Some change 2!")
+  proc("git", "init").call(cwd = T.workspace)
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit").call(cwd = T.workspace)
+  proc("git", "tag", "-a", "v1.0.0", "-m", "v1.0.0").call(cwd = T.workspace)
+  write(T.workspace / "some-file", "Some change!")
+  proc("git", "add", "--all").call(cwd = T.workspace)
+  proc("git", "commit", "-m", "Some commit 2").call(cwd = T.workspace)
+  write.over(T.workspace / "some-file", "Some change 2!")
 }
 def uncommittedChangesAfterTagAndCommit() = T.command {
   setupUncommittedChangesAfterTagAndCommit()
 
   assert("""1\.0\.0-2-[\da-f]{7}""".r.findFirstIn(project.publishVersion()).isDefined)
-  val hash = proc("git", "rev-parse", "HEAD").call().out.trim().take(7)
+  val hash = proc("git", "rev-parse", "HEAD").call(cwd = T.workspace).out.trim().take(7)
   assert(!project.publishVersion().contains(hash))
 }

--- a/mill-git/src/com/goyeau/mill/git/GitVersionModule.scala
+++ b/mill-git/src/com/goyeau/mill/git/GitVersionModule.scala
@@ -14,7 +14,8 @@ object GitVersionModule extends ExternalModule {
     */
   def version(hashLength: Int = 7, withSnapshotSuffix: Boolean = false): Command[String] =
     T.command {
-      val git            = Git.open(new File("."))
+      val workspacePath  = T.workspace
+      val git            = Git.open(workspacePath.toIO)
       val status         = git.status().call()
       val isDirty        = status.hasUncommittedChanges || !status.getUntracked.isEmpty
       val snapshotSuffix = if (withSnapshotSuffix) "-SNAPSHOT" else ""
@@ -45,7 +46,7 @@ object GitVersionModule extends ExternalModule {
       )
     }
 
-  private def uncommittedHash(git: Git, temp: Path, hashLength: Int) = {
+  private def uncommittedHash(git: Git, temp: Path, hashLength: Int): String = {
     val indexCopy = temp / "index"
     val _ = Try(copy(pwd / ".git" / "index", indexCopy, replaceExisting = true, createFolders = true))
 

--- a/mill-git/src/com/goyeau/mill/git/GitVersionModule.scala
+++ b/mill-git/src/com/goyeau/mill/git/GitVersionModule.scala
@@ -1,12 +1,12 @@
 package com.goyeau.mill.git
 
-import java.io.File
 import mill._
+import mill.api.Result.{Exception => MillException, OuterStack, Success => MillSuccess}
 import mill.define.{Command, Discover, ExternalModule}
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.RepositoryBuilder
 import os._
-import scala.util.Try
+import scala.util.{Failure => TryFailure, Success => TrySuccess, Try}
 
 object GitVersionModule extends ExternalModule {
 
@@ -21,9 +21,11 @@ object GitVersionModule extends ExternalModule {
       val snapshotSuffix = if (withSnapshotSuffix) "-SNAPSHOT" else ""
       def uncommitted()  = s"${uncommittedHash(git, T.ctx().dest, hashLength)}$snapshotSuffix"
 
-      Try(git.describe().setTags(true).setMatch("v[0-9]*").setAlways(true).call()).fold(
-        _ => uncommitted(),
-        description => {
+      val describeResult = Try(git.describe().setTags(true).setMatch("v[0-9]*").setAlways(true).call())
+
+      describeResult match {
+        case TryFailure(_) => MillSuccess(uncommitted())
+        case TrySuccess(description) =>
           val taggedRegex   = """v(\d.*?)(?:-(\d+)-g([\da-f]+))?""".r
           val untaggedRegex = """([\da-f]+)""".r
 
@@ -36,19 +38,20 @@ object GitVersionModule extends ExternalModule {
                 if (isDirty) s"-${distance.toInt + 1}-${uncommitted()}"
                 else s"-$distance-${hash.take(hashLength)}$snapshotSuffix"
               }
-              s"$tag$distanceHash"
+              MillSuccess(s"$tag$distanceHash")
             case untaggedRegex(hash) =>
-              if (isDirty) uncommitted()
-              else s"${hash.take(hashLength)}$snapshotSuffix"
-            case _ => throw new IllegalStateException(s"Unexpected git describe output: $description")
+              if (isDirty) MillSuccess(uncommitted())
+              else MillSuccess(s"${hash.take(hashLength)}$snapshotSuffix")
+            case _ =>
+              val exception = new IllegalStateException(s"Unexpected git describe output: $description")
+              MillException(exception, new OuterStack(exception.getStackTrace.toIndexedSeq))
           }
-        }
-      )
+      }
     }
 
   private def uncommittedHash(git: Git, temp: Path, hashLength: Int): String = {
     val indexCopy = temp / "index"
-    val _ = Try(copy(pwd / ".git" / "index", indexCopy, replaceExisting = true, createFolders = true))
+    val _         = Try(copy(pwd / ".git" / "index", indexCopy, replaceExisting = true, createFolders = true))
 
     // Use different index file to avoid messing up current git status
     val altGit = Git.wrap(
@@ -62,5 +65,5 @@ object GitVersionModule extends ExternalModule {
     cache.writeTree(altGit.getRepository.newObjectInserter()).abbreviate(hashLength).name()
   }
 
-  override lazy val millDiscover: Discover[this.type] = Discover[this.type]
+  override lazy val millDiscover = Discover[this.type]
 }


### PR DESCRIPTION
In mill 0.12, the following line fails because the workdir (`"."`) is now deep inside the mill-server directory, and that's not where we want to get the git repo from:

```
      val git            = Git.open(new File("."))
```

error:
```
om.goyeau.mill.git.GitVersionModule.version.super.GitVersionModule org.eclipse.jgit.errors.RepositoryNotFoundException: repository not found: /opt/agent/runners/0aa8062bdb914a303-4/_work/defung/test-repo/out/mill-server/5872f4ddb9601f7e0e0e05b9e73414d9af91f4ba-1/sandbox
    org.eclipse.jgit.lib.BaseRepositoryBuilder.build(BaseRepositoryBuilder.java:627)
    org.eclipse.jgit.api.Git.open(Git.java:93)
    org.eclipse.jgit.api.Git.open(Git.java:73)
    com.goyeau.mill.git.GitVersionModule$.$anonfun$version$2(GitVersionModule.scala:17)
```

Instead, we should be explicitly using `T.workspace` to get the root dir of the workspace.